### PR TITLE
Moves executables

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,22 +2,45 @@
 
 URL="https://github.com/cnorick/Mazemaker.git"
 folder="/tmp/Mazesolver"
-currentDir=`pwd`
+Dir="/opt/Mazemaker"
 
-mkdir mazemaker_support
 
-echo downloading source...
-git clone $URL $folder
+install(){
+	mkdir $Dir;
+	cd $Dir;
+	mkdir mazemaker_support;
 
-cd $folder/source
-make
+	echo downloading source...;
+	git clone $URL $folder;
+	cd $folder/source;
+	make;
 
-cp mazemake mazesolve mazeshow $currentDir/mazemaker_support
+	cp mazemake mazesolve mazeshow $Dir/mazemaker_support;
+	cd ..;
+	cp mazemaker $Dir;
 
-cd ..
-cp mazemaker $currentDir
+	ln -s $Dir/mazemaker /bin;
 
-cd $curentDir
+	echo deleting source...;
+	rm -rf $folder;
+}
 
-echo deleting source...
-rm -rf $folder
+clean(){
+	if [ -e $Dir ]; then
+		rm -fr $Dir;
+	fi;
+
+	if [ -L /bin/mazemaker ]; then
+		rm -fr /bin/mazemaker;
+	fi;
+}
+
+
+
+if [ $USER != "root" ]; then
+echo must run as root;
+exit;
+fi;
+
+clean;
+install;

--- a/mazemaker
+++ b/mazemaker
@@ -1,36 +1,34 @@
 #! /bin/sh
 
-R=$1
-C=$2
-folder=./mazemaker_support
+R=$1;
+C=$2;
+folder=/opt/Mazemaker/mazemaker_support;
+currentDir=`pwd`;
 
 clean(){
-	echo rm -f maze*.png
-	rm -f maze*.png
+	echo rm -f maze*.png;
+	rm -f maze*.png;
 }
 
 make(){
-	cd $folder
+	$folder/mazemake ${R:=60} ${C:=80} > maze.txt;
+	$folder/mazesolve < maze.txt > path.txt;
 
-		./mazemake ${R:=60} ${C:=80} > maze.txt
-		./mazesolve < maze.txt > path.txt 
-
-		mazename="maze_${R}x${C}.png"
-		pathname="maze_path_${R}x${C}.png"
+	mazename="maze_${R}x${C}.png";
+	pathname="maze_path_${R}x${C}.png";
 
 
-		./mazeshow 10 maze.txt | convert - $mazename
-		./mazeshow 10 maze.txt path.txt | convert - $pathname
+	$folder/mazeshow 10 maze.txt | convert - $mazename;
+	$folder/mazeshow 10 maze.txt path.txt | convert - $pathname;
 
-		mv $mazename $pathname ..
-		rm maze.txt path.txt
+	rm maze.txt path.txt;
 }
 
 
 
 
 if [ $R ] && [ $R = "clean" ]; then # make sure variable is not empty
-	clean
+	clean;
 else
-	make
-fi
+	make;
+fi;


### PR DESCRIPTION
- Executables are now put in /opt/Mazemaker during installation.
- symbolic link to mazemaker executable is put in bin.
- mazemaker executabel is updated to deal with these changes.
- fixes #15
